### PR TITLE
Rename heartbeat → reporting, add daily summary, fix close-event context

### DIFF
--- a/.github/workflows/daily-summary.lock.yml
+++ b/.github/workflows/daily-summary.lock.yml
@@ -22,58 +22,33 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"f15c87abf7fdc2633c98fc424a8280ec7f9df7ff4f7ef76ea0f83610b38daa6a","compiler_version":"v0.49.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"3f0b60708b0b6c6faf0f322223e4f4815b3e3efbe0df169f9526cf6d1ddfd759","compiler_version":"v0.49.5"}
 
-name: "Reporting"
+name: "Daily Summary"
 "on":
-  issue_comment:
-    types:
-    - created
-  issues:
-    types:
-    - closed
-    - edited
-  pull_request:
-    types:
-    - closed
-    - opened
-    - ready_for_review
-    - review_requested
-  pull_request_review:
-    types:
-    - submitted
-  pull_request_review_comment:
-    types:
-    - created
-  release:
-    types:
-    - published
+  schedule:
+  - cron: "0 8 * * *"
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: gh-aw-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: gh-aw-${{ github.workflow }}
 
-run-name: "Reporting"
+run-name: "Daily Summary"
 
 env:
   GH_AW_TARGET_PROJECT: ${{ vars.GH_AW_TARGET_PROJECT }}
 
 jobs:
   activation:
-    needs: pre_activation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         uses: github/gh-aw/actions/setup@a93e36ea4c3955aa749c6c422eac6b9abf968f12 # v0.49.5
@@ -98,21 +73,12 @@ jobs:
       - name: Check workflow file timestamps
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "reporting.lock.yml"
+          GH_AW_WORKFLOW_FILE: "daily-summary.lock.yml"
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/check_workflow_timestamp_api.cjs');
-            await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/compute_text.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -126,7 +92,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         run: |
           bash /opt/gh-aw/actions/create_prompt_first.sh
           {
@@ -170,14 +135,11 @@ jobs:
           </github-context>
           
           GH_AW_PROMPT_EOF
-          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
-            cat "/opt/gh-aw/prompts/pr_context_prompt.md"
-          fi
           cat << 'GH_AW_PROMPT_EOF'
           </system>
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF'
-          {{#runtime-import reporting.md}}
+          {{#runtime-import daily-summary.md}}
           GH_AW_PROMPT_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
@@ -202,8 +164,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -222,9 +182,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -250,6 +208,8 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -259,7 +219,7 @@ jobs:
       GH_AW_SAFE_OUTPUTS: /opt/gh-aw/safeoutputs/outputs.jsonl
       GH_AW_SAFE_OUTPUTS_CONFIG_PATH: /opt/gh-aw/safeoutputs/config.json
       GH_AW_SAFE_OUTPUTS_TOOLS_PATH: /opt/gh-aw/safeoutputs/tools.json
-      GH_AW_WORKFLOW_ID_SANITIZED: reporting
+      GH_AW_WORKFLOW_ID_SANITIZED: dailysummary
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       has_patch: ${{ steps.collect_output.outputs.has_patch }}
@@ -317,7 +277,7 @@ jobs:
               version: "",
               agent_version: "0.0.414",
               cli_version: "v0.49.5",
-              workflow_name: "Reporting",
+              workflow_name: "Daily Summary",
               experimental: false,
               supports_tools_allowlist: true,
               run_id: context.runId,
@@ -896,7 +856,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Reporting"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -909,7 +869,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Reporting"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -922,10 +882,10 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Reporting"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "reporting"
+          GH_AW_WORKFLOW_ID: "daily-summary"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_GROUP_REPORTS: "false"
@@ -941,7 +901,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Reporting"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -959,6 +919,8 @@ jobs:
     if: needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true'
     runs-on: ubuntu-latest
     permissions: {}
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     timeout-minutes: 10
     outputs:
       success: ${{ steps.parse_results.outputs.success }}
@@ -987,7 +949,7 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Reporting"
+          WORKFLOW_NAME: "Daily Summary"
           WORKFLOW_DESCRIPTION: "No description provided"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1053,30 +1015,6 @@ jobs:
           path: /tmp/gh-aw/threat-detection/detection.log
           if-no-files-found: ignore
 
-  pre_activation:
-    if: (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-    steps:
-      - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@a93e36ea4c3955aa749c6c422eac6b9abf968f12 # v0.49.5
-        with:
-          destination: /opt/gh-aw/actions
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REQUIRED_ROLES: admin,maintainer,write
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/check_membership.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - agent
@@ -1088,8 +1026,8 @@ jobs:
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_WORKFLOW_ID: "reporting"
-      GH_AW_WORKFLOW_NAME: "Reporting"
+      GH_AW_WORKFLOW_ID: "daily-summary"
+      GH_AW_WORKFLOW_NAME: "Daily Summary"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}

--- a/.github/workflows/reporting.lock.yml
+++ b/.github/workflows/reporting.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"f15c87abf7fdc2633c98fc424a8280ec7f9df7ff4f7ef76ea0f83610b38daa6a","compiler_version":"v0.49.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"291fa7dbf68722976d93ec84636389c2de36dbd6fcf126c16ffd47196ce33e85","compiler_version":"v0.49.5"}
 
 name: "Reporting"
 "on":
@@ -48,6 +48,7 @@ name: "Reporting"
   release:
     types:
     - published
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .worktrees/
+trials/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Heartbeat — Agent Instructions
+
+## Testing Workflows
+
+All workflows live in `workflows/` and are compiled with `gh aw compile`. Before merging any PR that modifies workflows:
+
+1. Ensure the workflow has a `workflow_dispatch:` trigger (required for `gh aw trial`)
+2. Recompile: `gh aw compile --dir workflows`
+3. Copy lock files: `cp workflows/*.lock.yml .github/workflows/`
+4. Validate: `gh aw compile --dir workflows --strict --no-emit --validate --verbose` (must pass with 0 errors)
+5. Run trials against representative events:
+
+   ```bash
+   # Test with a specific issue or PR as context
+   gh aw trial ./workflows/<workflow>.md \
+     -s e-straight/heartbeat \
+     --trigger-context <issue-or-pr-url> \
+     --verbose --yes
+
+   # Test daily summary (no trigger context needed)
+   gh aw trial ./workflows/daily-summary.md \
+     -s e-straight/heartbeat \
+     --verbose --yes
+   ```
+
+6. Review trial output in `trials/*.json` — verify status is "completed" and safe outputs contain well-formed status updates
+7. If trials fail due to missing variables in the temp repo, use `--host-repo .` instead of `-s`

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Never miss a beat. Automatically surface and summarize what's actually happening
 # Install the gh-aw extension
 gh extension install github/gh-aw
 
-# Add the workflow to your repo
-gh aw add-wizard e-straight/heartbeat/heartbeat
+# Add the workflows to your repo
+gh aw add-wizard e-straight/heartbeat/reporting
+gh aw add-wizard e-straight/heartbeat/daily-summary
 
 # Set your project board URL (run from inside your repo)
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -24,30 +25,26 @@ gh aw secrets set GH_AW_PROJECT_GITHUB_TOKEN --value "ghp_your_token_here"
 
 # Commit and push
 git add .github/workflows/
-git commit -m "Add heartbeat workflow"
+git commit -m "Add reporting workflow"
 git push
 ```
 
-## What it tracks 📡
+## Workflows
 
-- **PR merged**: summarizes the change, author, reviewers, and target branch
-- **PR closed without merge**: notes it wasn't merged and why
-- **PR opened**: notes when new work begins with author and branch info
-- **PR ready for review**: signals when a draft PR is ready for feedback
-- **Review requested**: tracks who's being asked to review
-- **Review submitted**: captures approvals, change requests, and review comments
-- **Inline review comment**: tracks line-level code review feedback with file path context
-- **Issue closed**: captures resolution, who closed it, and assignees
-- **Issue edited**: reports what changed (title, body, labels)
-- **Comments**: summarizes new comments on issues and PRs with a direct link
-- **Release published**: summarizes shipped releases with tag and changelog
+### Reporting
+
+Event-driven status updates. Every meaningful repository event — PR merges, reviews, issue changes, comments, releases — triggers an AI-generated status update on your GitHub Project board.
+
+### Daily Summary
+
+A nightly digest of all status updates from the past 24 hours, grouped by category (PRs, Issues, Releases). Runs on a cron schedule at midnight Pacific (08:00 UTC) and posts a scannable summary to your project board.
 
 ## Prerequisites 📋
 
 - [GitHub CLI](https://cli.github.com) (`gh`) v2.0+
 - The [`gh-aw`](https://github.com/github/gh-aw) extension
 - A [GitHub Project](https://docs.github.com/en/issues/planning-and-tracking-with-projects) (v2)
-- A [personal access token](https://github.com/settings/tokens/new?description=gh-aw-heartbeat&scopes=project,read:org) with `project` and `read:org` scopes
+- A [personal access token](https://github.com/settings/tokens/new?description=gh-aw-reporting&scopes=project,read:org) with `project` and `read:org` scopes
 
 ## License
 

--- a/docs/daily-summary.html
+++ b/docs/daily-summary.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Heartbeat 💓 | Agentic Workflow</title>
-  <meta name="description" content="AI-powered GitHub project status updates. Automatically post summaries for PR lifecycle events, code reviews, issue changes, comments, and releases.">
+  <title>Daily Summary | Heartbeat</title>
+  <meta name="description" content="Nightly digest of all project status updates. Automatically groups PR, issue, and release activity from the past 24 hours into a scannable summary.">
   <style>
     /* ===== Reset & Custom Properties ===== */
     *, *::before, *::after {
@@ -144,79 +144,6 @@
       max-width: 640px;
       margin: 0 auto 48px;
       line-height: 1.5;
-    }
-
-    /* Terminal Mockup */
-    .terminal-wrapper {
-      max-width: 620px;
-      margin: 0 auto;
-      border-radius: 12px;
-      border: 1px solid rgba(215, 122, 147, 0.2);
-      background: var(--bg-secondary);
-      overflow: hidden;
-      box-shadow:
-        0 0 40px rgba(215, 122, 147, 0.06),
-        0 0 80px rgba(215, 122, 147, 0.03);
-      animation: terminal-glow 4s ease-in-out infinite;
-    }
-
-    @keyframes terminal-glow {
-      0%, 100% {
-        box-shadow:
-          0 0 40px rgba(215, 122, 147, 0.06),
-          0 0 80px rgba(215, 122, 147, 0.03);
-        border-color: rgba(215, 122, 147, 0.2);
-      }
-      50% {
-        box-shadow:
-          0 0 60px rgba(215, 122, 147, 0.12),
-          0 0 120px rgba(215, 122, 147, 0.06);
-        border-color: rgba(215, 122, 147, 0.35);
-      }
-    }
-
-    .terminal-header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 16px;
-      background: rgba(255, 255, 255, 0.03);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    }
-
-    .terminal-dot {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-    }
-
-    .terminal-dot.red { background: #ff5f57; }
-    .terminal-dot.yellow { background: #febc2e; }
-    .terminal-dot.green { background: #28c840; }
-
-    .terminal-title {
-      flex: 1;
-      text-align: center;
-      font-size: 0.75rem;
-      color: var(--text-muted);
-    }
-
-    .terminal-body {
-      padding: 20px 24px;
-      position: relative;
-    }
-
-    .terminal-body code {
-      display: block;
-      font-size: 0.9375rem;
-      color: var(--text-primary);
-      white-space: nowrap;
-      overflow-x: auto;
-    }
-
-    .terminal-body .prompt {
-      color: var(--accent);
-      user-select: none;
     }
 
     /* ===== Features ===== */
@@ -421,92 +348,43 @@
       box-shadow: 0 0 20px rgba(215, 122, 147, 0.25);
     }
 
-    /* ===== Prerequisites ===== */
-    .prereqs {
+    /* ===== Schedule Info Card ===== */
+    .schedule {
       background: var(--bg-primary);
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
-      padding: 60px 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
     }
 
-    .prereqs .container > .section-subtitle {
-      margin-bottom: 32px;
-    }
-
-    .prereqs-list {
-      list-style: none;
-      display: grid;
-      gap: 16px;
+    .schedule-card {
+      padding: 32px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      background: var(--bg-secondary);
       max-width: 640px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .prereqs-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: 12px;
+    .schedule-card:hover {
+      border-color: rgba(215, 122, 147, 0.3);
+      box-shadow: 0 0 30px rgba(215, 122, 147, 0.05);
+    }
+
+    .schedule-card p {
       font-size: 0.9375rem;
       color: var(--text-muted);
       line-height: 1.6;
+      margin-bottom: 12px;
     }
 
-    .prereqs-list li::before {
-      content: '';
-      display: block;
-      width: 6px;
-      height: 6px;
-      background: var(--accent);
-      border-radius: 50%;
-      margin-top: 9px;
-      flex-shrink: 0;
+    .schedule-card p:last-child {
+      margin-bottom: 0;
     }
 
-    .prereqs-list code {
+    .schedule-card code {
       background: rgba(255, 255, 255, 0.06);
       padding: 2px 6px;
       border-radius: 4px;
       font-size: 0.8125rem;
       color: var(--text-primary);
-    }
-
-    /* ===== Why Section ===== */
-    .why {
-      background: var(--bg-gradient);
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
-    }
-
-    .why .container > .section-subtitle {
-      margin-bottom: 48px;
-    }
-
-    .why-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 24px;
-    }
-
-    .why-card {
-      padding: 32px;
-      border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: var(--bg-secondary);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .why-card:hover {
-      border-color: rgba(215, 122, 147, 0.3);
-      box-shadow: 0 0 30px rgba(215, 122, 147, 0.05);
-    }
-
-    .why-card h3 {
-      font-size: 1.125rem;
-      font-weight: 700;
-      margin-bottom: 8px;
-      color: var(--text-primary);
-    }
-
-    .why-card p {
-      font-size: 0.9375rem;
-      color: var(--text-muted);
-      line-height: 1.6;
     }
 
     /* ===== Site Navigation ===== */
@@ -592,94 +470,6 @@
       color: var(--accent);
     }
 
-    /* ===== Workflow Overview Cards ===== */
-    .workflows-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-      gap: 24px;
-    }
-
-    .workflow-card {
-      padding: 36px;
-      border-radius: 14px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: var(--bg-secondary);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .workflow-card:hover {
-      border-color: rgba(215, 122, 147, 0.3);
-      box-shadow: 0 0 40px rgba(215, 122, 147, 0.08);
-    }
-
-    .workflow-badge {
-      display: inline-block;
-      padding: 4px 12px;
-      font-size: 0.6875rem;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--accent);
-      background: rgba(215, 122, 147, 0.1);
-      border-radius: 20px;
-      margin-bottom: 16px;
-    }
-
-    .workflow-card h3 {
-      font-size: 1.375rem;
-      font-weight: 700;
-      color: var(--text-primary);
-      margin-bottom: 12px;
-    }
-
-    .workflow-card > p {
-      font-size: 0.9375rem;
-      color: var(--text-muted);
-      line-height: 1.6;
-      margin-bottom: 20px;
-    }
-
-    .workflow-card ul {
-      list-style: none;
-      margin-bottom: 24px;
-    }
-
-    .workflow-card ul li {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      font-size: 0.875rem;
-      color: var(--text-muted);
-      line-height: 1.5;
-      padding: 4px 0;
-    }
-
-    .workflow-card ul li::before {
-      content: '';
-      display: block;
-      width: 5px;
-      height: 5px;
-      background: var(--accent);
-      border-radius: 50%;
-      margin-top: 7px;
-      flex-shrink: 0;
-    }
-
-    .card-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 0.875rem;
-      font-weight: 600;
-      color: var(--accent);
-      transition: gap 0.2s ease;
-    }
-
-    .card-link:hover {
-      gap: 10px;
-      color: var(--accent-hover);
-    }
-
     /* ===== Footer ===== */
     footer {
       padding: 40px 0;
@@ -733,15 +523,7 @@
         font-size: 1rem;
       }
 
-      .terminal-body code {
-        font-size: 0.8125rem;
-      }
-
       .features-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .workflows-grid {
         grid-template-columns: 1fr;
       }
 
@@ -766,9 +548,9 @@
       <svg viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 4.5L6 8l3.5-3.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
     <div class="nav-menu">
-      <a href="index.html" class="nav-link active">Home</a>
+      <a href="index.html" class="nav-link">Home</a>
       <a href="reporting.html" class="nav-link">Reporting</a>
-      <a href="daily-summary.html" class="nav-link">Daily Summary</a>
+      <a href="daily-summary.html" class="nav-link active">Daily Summary</a>
     </div>
   </nav>
 
@@ -776,37 +558,121 @@
   <section class="hero">
     <div class="container">
       <h1>
-        <span class="accent">Heartbeat</span> 💓
+        <span class="accent">Daily Summary</span>
       </h1>
 
       <p class="subtitle">
-        Never miss a beat. Automatically surface and summarize what's
-        actually happening in your codebase, powered by GitHub
-        Agentic Workflows.
+        A nightly digest of all project activity from the past 24 hours. Status updates grouped by category for a scannable overview.
       </p>
+    </div>
+  </section>
 
-      <div class="terminal-wrapper">
-        <div class="terminal-header">
-          <span class="terminal-dot red"></span>
-          <span class="terminal-dot yellow"></span>
-          <span class="terminal-dot green"></span>
-          <span class="terminal-title">Terminal</span>
-          <span style="width: 36px;"></span>
+  <!-- ===== How It Works ===== -->
+  <section class="features">
+    <div class="container">
+      <p class="section-label">How it works</p>
+      <h2 class="section-title">Three steps to your daily digest</h2>
+      <p class="section-subtitle">The workflow runs automatically every night, collecting and organizing the day's activity into a single update.</p>
+
+      <div class="features-grid">
+
+        <!-- Collects Updates -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: clock -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7-3.25v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5a.75.75 0 0 1 1.5 0Z"/></svg>
+          </div>
+          <h3>Collects Updates</h3>
+          <p>Every day at midnight Pacific (08:00 UTC), the workflow queries all ProjectV2StatusUpdate objects posted to your project in the last 24 hours.</p>
         </div>
-        <div class="terminal-body">
-          <code><span class="prompt">$</span> gh aw add-wizard e-straight/heartbeat/reporting</code>
-          <code style="margin-top: 4px;"><span class="prompt">$</span> gh aw add-wizard e-straight/heartbeat/daily-summary</code>
+
+        <!-- Groups by Category -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: list-unordered -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 3.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm0 5a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm0 5a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/></svg>
+          </div>
+          <h3>Groups by Category</h3>
+          <p>Updates are automatically categorized into Pull Requests, Issues, and Releases based on their content, making the digest easy to scan.</p>
         </div>
+
+        <!-- Posts the Digest -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: project -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0ZM1.5 1.75v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM11.75 3a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5a.75.75 0 0 1 .75-.75Zm-8.25.75a.75.75 0 0 1 1.5 0v5.5a.75.75 0 0 1-1.5 0ZM8 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 3Z"/></svg>
+          </div>
+          <h3>Posts the Digest</h3>
+          <p>The composed summary is posted as a new ProjectV2StatusUpdate on your target project board, giving you a single daily overview of all repository activity.</p>
+        </div>
+
       </div>
     </div>
   </section>
 
-  <!-- ===== Setup Steps ===== -->
+  <!-- ===== Digest Categories ===== -->
+  <section class="features" style="border-top: 1px solid rgba(255, 255, 255, 0.06); background: var(--bg-gradient);">
+    <div class="container">
+      <p class="section-label">Categories</p>
+      <h2 class="section-title">What's in the digest</h2>
+      <p class="section-subtitle">Each daily summary groups activity into three categories so you can quickly find what matters.</p>
+
+      <div class="features-grid">
+
+        <!-- Pull Requests -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: git-merge -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5 3.254V3.25v.005a.75.75 0 1 1 0-.005zm.45 1.9a2.25 2.25 0 1 0-1.95.218v5.256a2.25 2.25 0 1 0 1.5 0V7.123A5.735 5.735 0 0 0 9.25 9h1.378a2.251 2.251 0 1 0 0-1.5H9.25a4.25 4.25 0 0 1-3.8-2.346zM12.75 9a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5zm-8.5 4.5a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z"/></svg>
+          </div>
+          <h3>Pull Requests</h3>
+          <p>Merges, opens, reviews, review requests, inline comments, and PR closures from the past day.</p>
+        </div>
+
+        <!-- Issues -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: check-circle -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.78-9.72a.751.751 0 0 0-.018-1.042.751.751 0 0 0-1.042-.018L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042l2 2a.75.75 0 0 0 1.06 0Z"/></svg>
+          </div>
+          <h3>Issues</h3>
+          <p>Issue closures, edits, and new comments summarized with resolution status and assignee context.</p>
+        </div>
+
+        <!-- Releases -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: tag -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
+          </div>
+          <h3>Releases</h3>
+          <p>New releases with tag, author, and changelog highlights from the past 24 hours.</p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== Schedule ===== -->
+  <section class="schedule">
+    <div class="container">
+      <p class="section-label">Schedule</p>
+      <h2 class="section-title">When it runs</h2>
+      <p class="section-subtitle" style="margin-bottom: 32px;">The daily summary runs on a fixed schedule, but you can also trigger it on demand.</p>
+
+      <div class="schedule-card">
+        <p>The workflow is triggered by a cron schedule: <code>0 8 * * *</code> — that's every day at midnight Pacific time (08:00 UTC).</p>
+        <p>It is also available via <code>workflow_dispatch</code>, so you can trigger it manually at any time for testing or on-demand summaries.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== Install ===== -->
   <section class="setup">
     <div class="container">
       <p class="section-label">Get started</p>
-      <h2 class="section-title">Three steps to automated project updates</h2>
-      <p class="section-subtitle">Install in under five minutes. No code changes, no app installations, no third-party services.</p>
+      <h2 class="section-title">Install in three steps</h2>
+      <p class="section-subtitle">Add the daily summary to your repository in under five minutes. No code changes, no app installations.</p>
 
       <div class="steps-grid">
         <!-- Step 1 -->
@@ -814,10 +680,9 @@
           <div class="step-number">1</div>
           <div class="step-content">
             <h3>Install the workflow</h3>
-            <p>Use the <code>gh-aw</code> extension to add the workflow to your repository.</p>
+            <p>Use the <code>gh-aw</code> extension to add the daily summary workflow to your repository.</p>
             <div class="code-block">
-              <pre>gh aw add-wizard e-straight/heartbeat/reporting
-gh aw add-wizard e-straight/heartbeat/daily-summary</pre>
+              <pre>gh aw add-wizard e-straight/heartbeat/daily-summary</pre>
               <button class="copy-btn" data-id="copy-step-1" onclick="copyCode(this)">Copy</button>
             </div>
           </div>
@@ -861,100 +726,6 @@ done</pre>
           </div>
         </div>
 
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Workflows ===== -->
-  <section class="features">
-    <div class="container">
-      <p class="section-label">Workflows</p>
-      <h2 class="section-title">Two workflows, complete visibility</h2>
-      <p class="section-subtitle">Install one or both to keep your GitHub Project board in sync with everything happening in your codebase.</p>
-
-      <div class="workflows-grid">
-        <!-- Reporting -->
-        <div class="workflow-card">
-          <span class="workflow-badge">Event-driven</span>
-          <h3>Reporting</h3>
-          <p>Every meaningful repository event triggers an AI-generated status update on your GitHub Project board.</p>
-          <ul>
-            <li>PR merges, opens, reviews, and comments</li>
-            <li>Issue closes, edits, and comments</li>
-            <li>Release publications</li>
-          </ul>
-          <a href="reporting.html" class="card-link">View details <span aria-hidden="true">&rarr;</span></a>
-        </div>
-
-        <!-- Daily Summary -->
-        <div class="workflow-card">
-          <span class="workflow-badge">Scheduled</span>
-          <h3>Daily Summary</h3>
-          <p>A nightly digest of all status updates from the past 24 hours, grouped by category.</p>
-          <ul>
-            <li>Runs at midnight Pacific (08:00 UTC)</li>
-            <li>Groups updates by PRs, Issues, and Releases</li>
-            <li>Scannable summary posted to your board</li>
-          </ul>
-          <a href="daily-summary.html" class="card-link">View details <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Prerequisites ===== -->
-  <section class="prereqs">
-    <div class="container">
-      <p class="section-label">Before you begin</p>
-      <h2 class="section-title">Prerequisites</h2>
-      <p class="section-subtitle">Make sure you have these tools installed before running the setup commands.</p>
-
-      <ul class="prereqs-list">
-        <li><a href="https://cli.github.com" target="_blank" rel="noopener noreferrer">GitHub CLI</a> (<code>gh</code>), version 2.0 or later</li>
-        <li>A <a href="https://docs.github.com/en/issues/planning-and-tracking-with-projects" target="_blank" rel="noopener noreferrer">GitHub Project</a> (v2) linked to your repository</li>
-        <li>The <a href="https://github.com/github/gh-aw" target="_blank" rel="noopener noreferrer"><code>gh-aw</code></a> extension (install below)</li>
-      </ul>
-      <div class="code-block" style="margin-top: 20px; max-width: 640px;">
-        <pre>gh extension install github/gh-aw</pre>
-        <button class="copy-btn" data-id="copy-prereq" onclick="copyCode(this)">Copy</button>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Why Agentic Workflows ===== -->
-  <section class="why">
-    <div class="container">
-      <p class="section-label">Why agentic workflows</p>
-      <h2 class="section-title">AI agents with guardrails, not blank checks</h2>
-      <p class="section-subtitle">The <code>gh-aw</code> framework treats AI agents as untrusted by default and enforces security at every layer.</p>
-
-      <div class="why-grid">
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: shield-lock -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8.533.133a1.75 1.75 0 0 0-1.066 0l-5.25 1.68A1.75 1.75 0 0 0 1 3.48V7c0 1.566.32 3.182 1.303 4.682.983 1.498 2.585 2.813 5.032 3.855a1.697 1.697 0 0 0 1.33 0c2.447-1.042 4.049-2.357 5.032-3.855C14.68 10.182 15 8.566 15 7V3.48a1.75 1.75 0 0 0-1.217-1.667Zm-.61 1.429a.25.25 0 0 1 .153 0l5.25 1.68a.25.25 0 0 1 .174.238V7c0 1.358-.275 2.666-1.057 3.86-.784 1.194-2.121 2.34-4.366 3.297a.196.196 0 0 1-.154 0c-2.245-.956-3.582-2.104-4.366-3.298C2.775 9.666 2.5 8.36 2.5 7V3.48a.25.25 0 0 1 .174-.238Z"/></svg>
-          </div>
-          <h3>Least-privilege permissions</h3>
-          <p>Agents run with read-only permissions by default. Write operations are never granted directly. They flow through safe-output jobs with scoped, validated access.</p>
-        </div>
-
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: check-circle -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.78-9.72a.751.751 0 0 0-.018-1.042.751.751 0 0 0-1.042-.018L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042l2 2a.75.75 0 0 0 1.06 0Z"/></svg>
-          </div>
-          <h3>Safe outputs</h3>
-          <p>Agent output is captured as structured data, scanned for threats like secret leaks and injection attacks, then executed by separate jobs, not by the agent itself.</p>
-        </div>
-
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: lock -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4 4a4 4 0 0 1 8 0v2h.25c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25v-5.5C2 6.784 2.784 6 3.75 6H4Zm8.25 3.5h-8.5a.25.25 0 0 0-.25.25v5.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25ZM10.5 6V4a2.5 2.5 0 1 0-5 0v2Z"/></svg>
-          </div>
-          <h3>Reproducible &amp; auditable</h3>
-          <p>Markdown workflows compile to pinned <code>.lock.yml</code> files with SHA-locked actions, validated schemas, and hardened configs. What you review is what runs.</p>
-        </div>
       </div>
     </div>
   </section>

--- a/docs/reporting.html
+++ b/docs/reporting.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Heartbeat 💓 | Agentic Workflow</title>
-  <meta name="description" content="AI-powered GitHub project status updates. Automatically post summaries for PR lifecycle events, code reviews, issue changes, comments, and releases.">
+  <title>Reporting | Heartbeat</title>
+  <meta name="description" content="Event-driven GitHub Project status updates. Automatically post summaries for PR lifecycle events, code reviews, issue changes, comments, and releases.">
   <style>
     /* ===== Reset & Custom Properties ===== */
     *, *::before, *::after {
@@ -144,79 +144,6 @@
       max-width: 640px;
       margin: 0 auto 48px;
       line-height: 1.5;
-    }
-
-    /* Terminal Mockup */
-    .terminal-wrapper {
-      max-width: 620px;
-      margin: 0 auto;
-      border-radius: 12px;
-      border: 1px solid rgba(215, 122, 147, 0.2);
-      background: var(--bg-secondary);
-      overflow: hidden;
-      box-shadow:
-        0 0 40px rgba(215, 122, 147, 0.06),
-        0 0 80px rgba(215, 122, 147, 0.03);
-      animation: terminal-glow 4s ease-in-out infinite;
-    }
-
-    @keyframes terminal-glow {
-      0%, 100% {
-        box-shadow:
-          0 0 40px rgba(215, 122, 147, 0.06),
-          0 0 80px rgba(215, 122, 147, 0.03);
-        border-color: rgba(215, 122, 147, 0.2);
-      }
-      50% {
-        box-shadow:
-          0 0 60px rgba(215, 122, 147, 0.12),
-          0 0 120px rgba(215, 122, 147, 0.06);
-        border-color: rgba(215, 122, 147, 0.35);
-      }
-    }
-
-    .terminal-header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 16px;
-      background: rgba(255, 255, 255, 0.03);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    }
-
-    .terminal-dot {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-    }
-
-    .terminal-dot.red { background: #ff5f57; }
-    .terminal-dot.yellow { background: #febc2e; }
-    .terminal-dot.green { background: #28c840; }
-
-    .terminal-title {
-      flex: 1;
-      text-align: center;
-      font-size: 0.75rem;
-      color: var(--text-muted);
-    }
-
-    .terminal-body {
-      padding: 20px 24px;
-      position: relative;
-    }
-
-    .terminal-body code {
-      display: block;
-      font-size: 0.9375rem;
-      color: var(--text-primary);
-      white-space: nowrap;
-      overflow-x: auto;
-    }
-
-    .terminal-body .prompt {
-      color: var(--accent);
-      user-select: none;
     }
 
     /* ===== Features ===== */
@@ -421,94 +348,6 @@
       box-shadow: 0 0 20px rgba(215, 122, 147, 0.25);
     }
 
-    /* ===== Prerequisites ===== */
-    .prereqs {
-      background: var(--bg-primary);
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
-      padding: 60px 0;
-    }
-
-    .prereqs .container > .section-subtitle {
-      margin-bottom: 32px;
-    }
-
-    .prereqs-list {
-      list-style: none;
-      display: grid;
-      gap: 16px;
-      max-width: 640px;
-    }
-
-    .prereqs-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: 12px;
-      font-size: 0.9375rem;
-      color: var(--text-muted);
-      line-height: 1.6;
-    }
-
-    .prereqs-list li::before {
-      content: '';
-      display: block;
-      width: 6px;
-      height: 6px;
-      background: var(--accent);
-      border-radius: 50%;
-      margin-top: 9px;
-      flex-shrink: 0;
-    }
-
-    .prereqs-list code {
-      background: rgba(255, 255, 255, 0.06);
-      padding: 2px 6px;
-      border-radius: 4px;
-      font-size: 0.8125rem;
-      color: var(--text-primary);
-    }
-
-    /* ===== Why Section ===== */
-    .why {
-      background: var(--bg-gradient);
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
-    }
-
-    .why .container > .section-subtitle {
-      margin-bottom: 48px;
-    }
-
-    .why-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 24px;
-    }
-
-    .why-card {
-      padding: 32px;
-      border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: var(--bg-secondary);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .why-card:hover {
-      border-color: rgba(215, 122, 147, 0.3);
-      box-shadow: 0 0 30px rgba(215, 122, 147, 0.05);
-    }
-
-    .why-card h3 {
-      font-size: 1.125rem;
-      font-weight: 700;
-      margin-bottom: 8px;
-      color: var(--text-primary);
-    }
-
-    .why-card p {
-      font-size: 0.9375rem;
-      color: var(--text-muted);
-      line-height: 1.6;
-    }
-
     /* ===== Site Navigation ===== */
     .site-nav {
       position: fixed;
@@ -592,94 +431,6 @@
       color: var(--accent);
     }
 
-    /* ===== Workflow Overview Cards ===== */
-    .workflows-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-      gap: 24px;
-    }
-
-    .workflow-card {
-      padding: 36px;
-      border-radius: 14px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: var(--bg-secondary);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .workflow-card:hover {
-      border-color: rgba(215, 122, 147, 0.3);
-      box-shadow: 0 0 40px rgba(215, 122, 147, 0.08);
-    }
-
-    .workflow-badge {
-      display: inline-block;
-      padding: 4px 12px;
-      font-size: 0.6875rem;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--accent);
-      background: rgba(215, 122, 147, 0.1);
-      border-radius: 20px;
-      margin-bottom: 16px;
-    }
-
-    .workflow-card h3 {
-      font-size: 1.375rem;
-      font-weight: 700;
-      color: var(--text-primary);
-      margin-bottom: 12px;
-    }
-
-    .workflow-card > p {
-      font-size: 0.9375rem;
-      color: var(--text-muted);
-      line-height: 1.6;
-      margin-bottom: 20px;
-    }
-
-    .workflow-card ul {
-      list-style: none;
-      margin-bottom: 24px;
-    }
-
-    .workflow-card ul li {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      font-size: 0.875rem;
-      color: var(--text-muted);
-      line-height: 1.5;
-      padding: 4px 0;
-    }
-
-    .workflow-card ul li::before {
-      content: '';
-      display: block;
-      width: 5px;
-      height: 5px;
-      background: var(--accent);
-      border-radius: 50%;
-      margin-top: 7px;
-      flex-shrink: 0;
-    }
-
-    .card-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 0.875rem;
-      font-weight: 600;
-      color: var(--accent);
-      transition: gap 0.2s ease;
-    }
-
-    .card-link:hover {
-      gap: 10px;
-      color: var(--accent-hover);
-    }
-
     /* ===== Footer ===== */
     footer {
       padding: 40px 0;
@@ -733,15 +484,7 @@
         font-size: 1rem;
       }
 
-      .terminal-body code {
-        font-size: 0.8125rem;
-      }
-
       .features-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .workflows-grid {
         grid-template-columns: 1fr;
       }
 
@@ -766,8 +509,8 @@
       <svg viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 4.5L6 8l3.5-3.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
     <div class="nav-menu">
-      <a href="index.html" class="nav-link active">Home</a>
-      <a href="reporting.html" class="nav-link">Reporting</a>
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="reporting.html" class="nav-link active">Reporting</a>
       <a href="daily-summary.html" class="nav-link">Daily Summary</a>
     </div>
   </nav>
@@ -776,37 +519,144 @@
   <section class="hero">
     <div class="container">
       <h1>
-        <span class="accent">Heartbeat</span> 💓
+        <span class="accent">Reporting</span>
       </h1>
 
       <p class="subtitle">
-        Never miss a beat. Automatically surface and summarize what's
-        actually happening in your codebase, powered by GitHub
-        Agentic Workflows.
+        Event-driven status updates for your GitHub Project board. Every meaningful repository event triggers an AI-generated summary.
       </p>
+    </div>
+  </section>
 
-      <div class="terminal-wrapper">
-        <div class="terminal-header">
-          <span class="terminal-dot red"></span>
-          <span class="terminal-dot yellow"></span>
-          <span class="terminal-dot green"></span>
-          <span class="terminal-title">Terminal</span>
-          <span style="width: 36px;"></span>
+  <!-- ===== Tracked Events ===== -->
+  <section class="features">
+    <div class="container">
+      <p class="section-label">Tracked events</p>
+      <h2 class="section-title">Every event that matters, captured</h2>
+      <p class="section-subtitle">Each repository event triggers a concise, AI-generated status update posted directly to your GitHub Project board.</p>
+
+      <div class="features-grid">
+
+        <!-- PR Merged -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: git-merge -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8-9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM4.25 4a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/></svg>
+          </div>
+          <h3>PR Merged</h3>
+          <p>When a pull request merges, the workflow summarizes the change, author, reviewers, and target branch into a concise project update.</p>
         </div>
-        <div class="terminal-body">
-          <code><span class="prompt">$</span> gh aw add-wizard e-straight/heartbeat/reporting</code>
-          <code style="margin-top: 4px;"><span class="prompt">$</span> gh aw add-wizard e-straight/heartbeat/daily-summary</code>
+
+        <!-- PR Closed -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: git-pull-request-closed -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 5.5a.75.75 0 0 1 .75.75v3.378a2.251 2.251 0 1 1-1.5 0V7.25a.75.75 0 0 1 .75-.75Zm-2.03-5.273a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1-1.06 1.06L12 3.56l-.72.72a.75.75 0 1 1-1.06-1.06ZM3.25 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"/></svg>
+          </div>
+          <h3>PR Closed</h3>
+          <p>Pull requests closed without merge are noted with the author and reason for closing, clearly distinguished from merged PRs.</p>
         </div>
+
+        <!-- PR Opened -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: git-pull-request -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></svg>
+          </div>
+          <h3>PR Opened</h3>
+          <p>New pull requests trigger a status update with author, branch info, and a summary of the change from the PR body.</p>
+        </div>
+
+        <!-- Ready for Review -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: eye -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.671 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.831.88 9.577.43 8.899a1.62 1.62 0 0 1 0-1.798c.45-.678 1.367-1.932 2.637-3.023C4.329 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.825-.742 3.955-1.715 1.124-.967 1.954-2.096 2.366-2.717a.12.12 0 0 0 0-.136c-.412-.621-1.242-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.824.742-3.955 1.715-1.124.967-1.954 2.096-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z"/></svg>
+          </div>
+          <h3>Ready for Review</h3>
+          <p>When a draft PR transitions to ready for review, the workflow captures the status change with author context.</p>
+        </div>
+
+        <!-- Review Requested -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: people -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2 5.5a3.5 3.5 0 1 1 5.898 2.549 5.508 5.508 0 0 1 3.034 4.084.75.75 0 1 1-1.482.235 4.001 4.001 0 0 0-6.9 0 .75.75 0 0 1-1.482-.236A5.507 5.507 0 0 1 4.6 8.049 3.5 3.5 0 0 1 2 5.5ZM5.5 4a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm5.5-.5a.75.75 0 0 1 .75-.75 3.5 3.5 0 0 1 .898 6.886 5.527 5.527 0 0 1 2.1 3.265.75.75 0 1 1-1.482.236 4.002 4.002 0 0 0-2.308-2.99.75.75 0 0 1 .042-1.397A2 2 0 0 0 11.75 4.75.75.75 0 0 1 11 4Z"/></svg>
+          </div>
+          <h3>Review Requested</h3>
+          <p>Tracks when a review is requested, noting who requested it and who was asked to review.</p>
+        </div>
+
+        <!-- Review Submitted -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: code-review -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm5.28 1.72a.75.75 0 0 1 0 1.06L5.31 7l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 0Zm2.44 0a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.69 7 9.22 5.53a.75.75 0 0 1 0-1.06Z"/></svg>
+          </div>
+          <h3>Review Submitted</h3>
+          <p>Review submissions are posted as status updates capturing approvals, change requests, and review feedback.</p>
+        </div>
+
+        <!-- Inline Comment -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: comment-discussion -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22V11.25a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>
+          </div>
+          <h3>Inline Comment</h3>
+          <p>Line-level code review comments are captured with file path, line number, and a summary of the feedback.</p>
+        </div>
+
+        <!-- Issue Closed -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: check-circle -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.78-9.72a.751.751 0 0 0-.018-1.042.751.751 0 0 0-1.042-.018L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042l2 2a.75.75 0 0 0 1.06 0Z"/></svg>
+          </div>
+          <h3>Issue Closed</h3>
+          <p>Closed issues trigger a status post with the resolution, who closed it, assignees, and a summary.</p>
+        </div>
+
+        <!-- Issue Edited -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: pencil -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"/></svg>
+          </div>
+          <h3>Issue Edited</h3>
+          <p>When an issue is edited, the workflow reports what changed — title, body, or labels — with who made the edit.</p>
+        </div>
+
+        <!-- Comments -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: comment -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.5 0v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25H2.75a.25.25 0 0 0-.25.25Z"/></svg>
+          </div>
+          <h3>Comments</h3>
+          <p>New comments on issues and PRs are summarized and posted as status updates with direct links.</p>
+        </div>
+
+        <!-- Release Published -->
+        <div class="feature-card">
+          <div class="feature-icon">
+            <!-- Octicon: tag -->
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
+          </div>
+          <h3>Release Published</h3>
+          <p>When a release is published, the workflow posts a summary with the tag, author, and changelog highlights.</p>
+        </div>
+
       </div>
     </div>
   </section>
 
-  <!-- ===== Setup Steps ===== -->
+  <!-- ===== Install ===== -->
   <section class="setup">
     <div class="container">
       <p class="section-label">Get started</p>
-      <h2 class="section-title">Three steps to automated project updates</h2>
-      <p class="section-subtitle">Install in under five minutes. No code changes, no app installations, no third-party services.</p>
+      <h2 class="section-title">Install in three steps</h2>
+      <p class="section-subtitle">Add event-driven reporting to your repository in under five minutes. No code changes, no app installations.</p>
 
       <div class="steps-grid">
         <!-- Step 1 -->
@@ -814,10 +664,9 @@
           <div class="step-number">1</div>
           <div class="step-content">
             <h3>Install the workflow</h3>
-            <p>Use the <code>gh-aw</code> extension to add the workflow to your repository.</p>
+            <p>Use the <code>gh-aw</code> extension to add the reporting workflow to your repository.</p>
             <div class="code-block">
-              <pre>gh aw add-wizard e-straight/heartbeat/reporting
-gh aw add-wizard e-straight/heartbeat/daily-summary</pre>
+              <pre>gh aw add-wizard e-straight/heartbeat/reporting</pre>
               <button class="copy-btn" data-id="copy-step-1" onclick="copyCode(this)">Copy</button>
             </div>
           </div>
@@ -861,100 +710,6 @@ done</pre>
           </div>
         </div>
 
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Workflows ===== -->
-  <section class="features">
-    <div class="container">
-      <p class="section-label">Workflows</p>
-      <h2 class="section-title">Two workflows, complete visibility</h2>
-      <p class="section-subtitle">Install one or both to keep your GitHub Project board in sync with everything happening in your codebase.</p>
-
-      <div class="workflows-grid">
-        <!-- Reporting -->
-        <div class="workflow-card">
-          <span class="workflow-badge">Event-driven</span>
-          <h3>Reporting</h3>
-          <p>Every meaningful repository event triggers an AI-generated status update on your GitHub Project board.</p>
-          <ul>
-            <li>PR merges, opens, reviews, and comments</li>
-            <li>Issue closes, edits, and comments</li>
-            <li>Release publications</li>
-          </ul>
-          <a href="reporting.html" class="card-link">View details <span aria-hidden="true">&rarr;</span></a>
-        </div>
-
-        <!-- Daily Summary -->
-        <div class="workflow-card">
-          <span class="workflow-badge">Scheduled</span>
-          <h3>Daily Summary</h3>
-          <p>A nightly digest of all status updates from the past 24 hours, grouped by category.</p>
-          <ul>
-            <li>Runs at midnight Pacific (08:00 UTC)</li>
-            <li>Groups updates by PRs, Issues, and Releases</li>
-            <li>Scannable summary posted to your board</li>
-          </ul>
-          <a href="daily-summary.html" class="card-link">View details <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Prerequisites ===== -->
-  <section class="prereqs">
-    <div class="container">
-      <p class="section-label">Before you begin</p>
-      <h2 class="section-title">Prerequisites</h2>
-      <p class="section-subtitle">Make sure you have these tools installed before running the setup commands.</p>
-
-      <ul class="prereqs-list">
-        <li><a href="https://cli.github.com" target="_blank" rel="noopener noreferrer">GitHub CLI</a> (<code>gh</code>), version 2.0 or later</li>
-        <li>A <a href="https://docs.github.com/en/issues/planning-and-tracking-with-projects" target="_blank" rel="noopener noreferrer">GitHub Project</a> (v2) linked to your repository</li>
-        <li>The <a href="https://github.com/github/gh-aw" target="_blank" rel="noopener noreferrer"><code>gh-aw</code></a> extension (install below)</li>
-      </ul>
-      <div class="code-block" style="margin-top: 20px; max-width: 640px;">
-        <pre>gh extension install github/gh-aw</pre>
-        <button class="copy-btn" data-id="copy-prereq" onclick="copyCode(this)">Copy</button>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== Why Agentic Workflows ===== -->
-  <section class="why">
-    <div class="container">
-      <p class="section-label">Why agentic workflows</p>
-      <h2 class="section-title">AI agents with guardrails, not blank checks</h2>
-      <p class="section-subtitle">The <code>gh-aw</code> framework treats AI agents as untrusted by default and enforces security at every layer.</p>
-
-      <div class="why-grid">
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: shield-lock -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8.533.133a1.75 1.75 0 0 0-1.066 0l-5.25 1.68A1.75 1.75 0 0 0 1 3.48V7c0 1.566.32 3.182 1.303 4.682.983 1.498 2.585 2.813 5.032 3.855a1.697 1.697 0 0 0 1.33 0c2.447-1.042 4.049-2.357 5.032-3.855C14.68 10.182 15 8.566 15 7V3.48a1.75 1.75 0 0 0-1.217-1.667Zm-.61 1.429a.25.25 0 0 1 .153 0l5.25 1.68a.25.25 0 0 1 .174.238V7c0 1.358-.275 2.666-1.057 3.86-.784 1.194-2.121 2.34-4.366 3.297a.196.196 0 0 1-.154 0c-2.245-.956-3.582-2.104-4.366-3.298C2.775 9.666 2.5 8.36 2.5 7V3.48a.25.25 0 0 1 .174-.238Z"/></svg>
-          </div>
-          <h3>Least-privilege permissions</h3>
-          <p>Agents run with read-only permissions by default. Write operations are never granted directly. They flow through safe-output jobs with scoped, validated access.</p>
-        </div>
-
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: check-circle -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.78-9.72a.751.751 0 0 0-.018-1.042.751.751 0 0 0-1.042-.018L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042l2 2a.75.75 0 0 0 1.06 0Z"/></svg>
-          </div>
-          <h3>Safe outputs</h3>
-          <p>Agent output is captured as structured data, scanned for threats like secret leaks and injection attacks, then executed by separate jobs, not by the agent itself.</p>
-        </div>
-
-        <div class="why-card">
-          <div class="feature-icon">
-            <!-- Octicon: lock -->
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4 4a4 4 0 0 1 8 0v2h.25c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25v-5.5C2 6.784 2.784 6 3.75 6H4Zm8.25 3.5h-8.5a.25.25 0 0 0-.25.25v5.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25ZM10.5 6V4a2.5 2.5 0 1 0-5 0v2Z"/></svg>
-          </div>
-          <h3>Reproducible &amp; auditable</h3>
-          <p>Markdown workflows compile to pinned <code>.lock.yml</code> files with SHA-locked actions, validated schemas, and hardened configs. What you review is what runs.</p>
-        </div>
       </div>
     </div>
   </section>

--- a/workflows/daily-summary.lock.yml
+++ b/workflows/daily-summary.lock.yml
@@ -22,46 +22,33 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"87c02b437c9a72c74a58173a1ec1dbb9e34fe3af6a091c95bcc17cb356fc594f","compiler_version":"v0.49.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"3f0b60708b0b6c6faf0f322223e4f4815b3e3efbe0df169f9526cf6d1ddfd759","compiler_version":"v0.49.5"}
 
-name: "Heartbeat"
+name: "Daily Summary"
 "on":
-  issue_comment:
-    types:
-    - created
-  issues:
-    types:
-    - closed
-    - edited
-  pull_request:
-    types:
-    - closed
+  schedule:
+  - cron: "0 8 * * *"
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}"
   cancel-in-progress: true
+  group: gh-aw-${{ github.workflow }}
 
-run-name: "Heartbeat"
+run-name: "Daily Summary"
 
 env:
   GH_AW_TARGET_PROJECT: ${{ vars.GH_AW_TARGET_PROJECT }}
 
 jobs:
   activation:
-    needs: pre_activation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         uses: github/gh-aw/actions/setup@a93e36ea4c3955aa749c6c422eac6b9abf968f12 # v0.49.5
@@ -86,21 +73,12 @@ jobs:
       - name: Check workflow file timestamps
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "heartbeat.lock.yml"
+          GH_AW_WORKFLOW_FILE: "daily-summary.lock.yml"
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/check_workflow_timestamp_api.cjs');
-            await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/compute_text.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -114,7 +92,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         run: |
           bash /opt/gh-aw/actions/create_prompt_first.sh
           {
@@ -158,14 +135,11 @@ jobs:
           </github-context>
           
           GH_AW_PROMPT_EOF
-          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
-            cat "/opt/gh-aw/prompts/pr_context_prompt.md"
-          fi
           cat << 'GH_AW_PROMPT_EOF'
           </system>
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF'
-          {{#runtime-import heartbeat.md}}
+          {{#runtime-import daily-summary.md}}
           GH_AW_PROMPT_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
@@ -190,8 +164,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -210,9 +182,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -238,6 +208,8 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -247,7 +219,7 @@ jobs:
       GH_AW_SAFE_OUTPUTS: /opt/gh-aw/safeoutputs/outputs.jsonl
       GH_AW_SAFE_OUTPUTS_CONFIG_PATH: /opt/gh-aw/safeoutputs/config.json
       GH_AW_SAFE_OUTPUTS_TOOLS_PATH: /opt/gh-aw/safeoutputs/tools.json
-      GH_AW_WORKFLOW_ID_SANITIZED: heartbeat
+      GH_AW_WORKFLOW_ID_SANITIZED: dailysummary
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       has_patch: ${{ steps.collect_output.outputs.has_patch }}
@@ -305,7 +277,7 @@ jobs:
               version: "",
               agent_version: "0.0.414",
               cli_version: "v0.49.5",
-              workflow_name: "Heartbeat",
+              workflow_name: "Daily Summary",
               experimental: false,
               supports_tools_allowlist: true,
               run_id: context.runId,
@@ -884,7 +856,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -897,7 +869,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -910,10 +882,10 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "heartbeat"
+          GH_AW_WORKFLOW_ID: "daily-summary"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_GROUP_REPORTS: "false"
@@ -929,7 +901,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Daily Summary"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -947,6 +919,8 @@ jobs:
     if: needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true'
     runs-on: ubuntu-latest
     permissions: {}
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     timeout-minutes: 10
     outputs:
       success: ${{ steps.parse_results.outputs.success }}
@@ -975,7 +949,7 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Heartbeat"
+          WORKFLOW_NAME: "Daily Summary"
           WORKFLOW_DESCRIPTION: "No description provided"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1041,30 +1015,6 @@ jobs:
           path: /tmp/gh-aw/threat-detection/detection.log
           if-no-files-found: ignore
 
-  pre_activation:
-    if: (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-    steps:
-      - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@a93e36ea4c3955aa749c6c422eac6b9abf968f12 # v0.49.5
-        with:
-          destination: /opt/gh-aw/actions
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REQUIRED_ROLES: admin,maintainer,write
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/check_membership.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - agent
@@ -1076,8 +1026,8 @@ jobs:
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_WORKFLOW_ID: "heartbeat"
-      GH_AW_WORKFLOW_NAME: "Heartbeat"
+      GH_AW_WORKFLOW_ID: "daily-summary"
+      GH_AW_WORKFLOW_NAME: "Daily Summary"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}

--- a/workflows/daily-summary.md
+++ b/workflows/daily-summary.md
@@ -1,0 +1,99 @@
+---
+name: Daily Summary
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+concurrency:
+  group: "gh-aw-${{ github.workflow }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+env:
+  GH_AW_TARGET_PROJECT: ${{ vars.GH_AW_TARGET_PROJECT }}
+tools:
+  github:
+    toolsets: [default, projects]
+safe-outputs:
+  github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
+  create-project-status-update:
+---
+
+You are Daily Summary, a project digest generator. Once per day, collect all recent status updates from the target GitHub Project and compose a scannable daily digest.
+
+## Step 1: Validate configuration
+
+Read the `GH_AW_TARGET_PROJECT` environment variable. It must be present and match the pattern:
+
+```
+https://github.com/(users|orgs)/<owner>/projects/<number>
+```
+
+If the variable is missing or does not match this pattern, **stop immediately** and report the error:
+
+> ERROR: `GH_AW_TARGET_PROJECT` is missing or malformed. Expected format: `https://github.com/users/<owner>/projects/<number>` or `https://github.com/orgs/<owner>/projects/<number>`.
+
+Do not proceed with any status update.
+
+## Step 2: Query recent status updates
+
+Using the GitHub MCP tools, query the target project's `ProjectV2StatusUpdate` objects from the past 24 hours. These are the status updates posted by the Reporting workflow via the `create-project-status-update` safe output.
+
+Parse the project URL to extract the owner and project number, then use the GraphQL API to fetch status updates:
+
+```graphql
+query($owner: String!, $number: Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      statusUpdates(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          body
+          createdAt
+          creator { login }
+        }
+      }
+    }
+  }
+}
+```
+
+Filter the results to only include updates created within the last 24 hours.
+
+## Step 3: Handle no activity
+
+If there are no status updates from the past 24 hours, post a brief status update:
+
+> **Daily Summary** — No activity reported in the last 24 hours.
+
+Then stop.
+
+## Step 4: Group and compose the digest
+
+If updates exist, group them by category based on their content:
+
+- **Pull Requests** — any update mentioning "PR #", "pull request", "merged", "review", or "inline comment"
+- **Issues** — any update mentioning "Issue #" or "issue"
+- **Releases** — any update mentioning "Release" or "published"
+
+Compose a scannable digest with this structure:
+
+```
+Daily Summary — <date>
+
+**Pull Requests** (<count>)
+- <summary of each PR-related update>
+
+**Issues** (<count>)
+- <summary of each issue-related update>
+
+**Releases** (<count>)
+- <summary of each release-related update>
+```
+
+Omit any category that has zero updates. Keep each bullet point to one line. Include the total number of updates at the top.
+
+## Step 5: Post the daily summary
+
+Create a project status update on the target project specified by `GH_AW_TARGET_PROJECT` with the composed digest. Keep the summary concise and scannable.

--- a/workflows/reporting.lock.yml
+++ b/workflows/reporting.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"f15c87abf7fdc2633c98fc424a8280ec7f9df7ff4f7ef76ea0f83610b38daa6a","compiler_version":"v0.49.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"291fa7dbf68722976d93ec84636389c2de36dbd6fcf126c16ffd47196ce33e85","compiler_version":"v0.49.5"}
 
 name: "Reporting"
 "on":
@@ -48,6 +48,7 @@ name: "Reporting"
   release:
     types:
     - published
+  workflow_dispatch:
 
 permissions: {}
 

--- a/workflows/reporting.lock.yml
+++ b/workflows/reporting.lock.yml
@@ -22,9 +22,9 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"9c7313114029ef01792f5d64bcd38666a728766e20413631ee0b747b5b9ed091","compiler_version":"v0.49.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"f15c87abf7fdc2633c98fc424a8280ec7f9df7ff4f7ef76ea0f83610b38daa6a","compiler_version":"v0.49.5"}
 
-name: "Heartbeat"
+name: "Reporting"
 "on":
   issue_comment:
     types:
@@ -52,10 +52,10 @@ name: "Heartbeat"
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}"
   cancel-in-progress: true
+  group: gh-aw-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
 
-run-name: "Heartbeat"
+run-name: "Reporting"
 
 env:
   GH_AW_TARGET_PROJECT: ${{ vars.GH_AW_TARGET_PROJECT }}
@@ -98,7 +98,7 @@ jobs:
       - name: Check workflow file timestamps
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "heartbeat.lock.yml"
+          GH_AW_WORKFLOW_FILE: "reporting.lock.yml"
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -177,7 +177,7 @@ jobs:
           </system>
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF'
-          {{#runtime-import heartbeat.md}}
+          {{#runtime-import reporting.md}}
           GH_AW_PROMPT_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
@@ -259,7 +259,7 @@ jobs:
       GH_AW_SAFE_OUTPUTS: /opt/gh-aw/safeoutputs/outputs.jsonl
       GH_AW_SAFE_OUTPUTS_CONFIG_PATH: /opt/gh-aw/safeoutputs/config.json
       GH_AW_SAFE_OUTPUTS_TOOLS_PATH: /opt/gh-aw/safeoutputs/tools.json
-      GH_AW_WORKFLOW_ID_SANITIZED: heartbeat
+      GH_AW_WORKFLOW_ID_SANITIZED: reporting
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       has_patch: ${{ steps.collect_output.outputs.has_patch }}
@@ -317,7 +317,7 @@ jobs:
               version: "",
               agent_version: "0.0.414",
               cli_version: "v0.49.5",
-              workflow_name: "Heartbeat",
+              workflow_name: "Reporting",
               experimental: false,
               supports_tools_allowlist: true,
               run_id: context.runId,
@@ -896,7 +896,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Reporting"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -909,7 +909,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Reporting"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |
@@ -922,10 +922,10 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Reporting"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "heartbeat"
+          GH_AW_WORKFLOW_ID: "reporting"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_GROUP_REPORTS: "false"
@@ -941,7 +941,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Heartbeat"
+          GH_AW_WORKFLOW_NAME: "Reporting"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -987,7 +987,7 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Heartbeat"
+          WORKFLOW_NAME: "Reporting"
           WORKFLOW_DESCRIPTION: "No description provided"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1088,8 +1088,8 @@ jobs:
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_WORKFLOW_ID: "heartbeat"
-      GH_AW_WORKFLOW_NAME: "Heartbeat"
+      GH_AW_WORKFLOW_ID: "reporting"
+      GH_AW_WORKFLOW_NAME: "Reporting"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}

--- a/workflows/reporting.md
+++ b/workflows/reporting.md
@@ -13,6 +13,7 @@ on:
     types: [created]
   release:
     types: [published]
+  workflow_dispatch:
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}"
   cancel-in-progress: true

--- a/workflows/reporting.md
+++ b/workflows/reporting.md
@@ -1,5 +1,5 @@
 ---
-name: Heartbeat
+name: Reporting
 on:
   issues:
     types: [closed, edited]
@@ -13,6 +13,9 @@ on:
     types: [created]
   release:
     types: [published]
+concurrency:
+  group: "gh-aw-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+  cancel-in-progress: true
 permissions:
   contents: read
   issues: read
@@ -27,7 +30,7 @@ safe-outputs:
   create-project-status-update:
 ---
 
-You are Heartbeat, a project status tracker. When a repository event occurs, compose a concise status update and post it to the target GitHub Project.
+You are Reporting, a project status tracker. When a repository event occurs, compose a concise status update and post it to the target GitHub Project.
 
 ## Step 1: Validate configuration
 
@@ -61,21 +64,21 @@ Read the GitHub event context to determine which event fired:
 
 ### If `pull_request` closed
 
-Query the pull request via GitHub MCP to check the `merged` field.
+Query the pull request via GitHub MCP to check the `merged` field. Also read the PR's comments and review threads to understand the full context of the change or closure.
 
 - **If merged:** Compose a status update with:
   - Title and PR number
   - Author
   - Reviewer(s) (if any)
   - Base/head branch
-  - One-sentence summary of the change
+  - One-sentence summary of the change (informed by PR body, comments, and review discussions)
 
   Example: "PR #42 merged: Add JWT session management — by @author, reviewed by @reviewer. Merges `feature/jwt` into `main`. Implements token-based auth replacing cookie sessions."
 
-- **If closed without merge:** Compose a status update noting it was **not** merged:
+- **If closed without merge:** Read the most recent comments to determine why the PR was closed. Compose a status update noting it was **not** merged:
   - Title and PR number
   - Author
-  - Reason for closing if discernible from the PR body or comments
+  - Reason for closing based on the closing comment or recent discussion (do not guess — use the actual stated reason)
 
   Example: "PR #14 closed without merge: Cookie sessions experiment — by @author. Superseded by JWT approach in PR #13."
 
@@ -131,13 +134,18 @@ Example: "Inline comment on PR #18 (Add rate limiting middleware) by @reviewer o
 
 ### If `issues` closed
 
+Read the issue's comments to understand the context of closure. Pay special attention to the most recent comment (often the closing comment) and any linked pull requests that may have resolved the issue.
+
 Compose a status update with:
 - Issue title and number
 - Who closed it
-- Resolution (completed, won't fix, duplicate — infer from labels or closing comment)
+- Resolution — determine from the closing comment, labels, and linked PRs whether the issue was completed, closed as not planned, a duplicate, or something else. Do not default to "completed" without evidence.
 - Assignees (if any)
+- One-sentence summary of the resolution context (from comments or linked PRs, not just the issue body)
 
-Example: "Issue #5 closed: Implement rate limiting middleware — closed by @user, assigned to @dev1, @dev2. Resolution: completed."
+Example (completed via PR): "Issue #5 closed: Implement rate limiting middleware — closed by @user via PR #18, assigned to @dev1. Resolution: completed. Rate limiting was implemented using a token bucket algorithm."
+
+Example (closed as not planned): "Issue #7 closed: Add WebSocket support — closed by @maintainer. Resolution: closed as not planned. Per discussion in #7, the team decided REST polling is sufficient for current requirements."
 
 ### If `issues` edited
 


### PR DESCRIPTION
## Summary

- **Rename** `heartbeat` workflow to `reporting` for clarity across all files (workflow, lock files, docs, README)
- **Add daily-summary workflow** — a nightly digest that collects the past 24 hours of status updates and posts a scannable summary grouped by category (PRs, Issues, Releases) to the project board
- **Fix cross-event concurrency cancellation** (#5) — concurrency groups now include `github.event_name` so simultaneous events for the same PR/issue no longer cancel each other
- **Fix close-event prompt context** (#6) — PR closed and issue closed prompts now read comments, review threads, and linked PRs for actual closure context instead of producing generic summaries

## Changes

| File | What changed |
|------|-------------|
| `workflows/reporting.md` | Renamed from `heartbeat.md`; added concurrency group with `event_name`; improved 7 close-event prompt lines |
| `workflows/daily-summary.md` | New workflow with schedule/dispatch triggers and concurrency group |
| `workflows/*.lock.yml` | Recompiled from source |
| `.github/workflows/*.lock.yml` | Recompiled from source |
| `README.md` | Updated workflow names and install instructions |
| `docs/` | Updated landing page nav; added reporting and daily-summary detail pages |

## Test plan

- [x] `gh aw compile --dir workflows --strict --no-emit --validate --verbose` passes with 0 errors
- [ ] Verify concurrency groups in lock files match source `.md` frontmatter
- [ ] Trigger a test PR close event and confirm the status update includes comment/review context
- [ ] Trigger `workflow_dispatch` on daily-summary and confirm it posts a digest

Closes #5, closes #6